### PR TITLE
Add GP2Y0A51SK0F 

### DIFF
--- a/examples/SharpDistSensorBasic/SharpDistSensorBasic.ino
+++ b/examples/SharpDistSensorBasic/SharpDistSensorBasic.ino
@@ -27,8 +27,7 @@ SOFTWARE.
 
 /*
 This example shows how to use the SharpDistSensor library to continuously
-read the sensor and display the analog value and the corrseponding distance
-in mm.
+read the sensor and display the measured distance in mm to the serial monitor.
 
 The library default values corresponding to the Sharp GP2Y0A60SZLF 5V sensor
 are used.


### PR DESCRIPTION
Greetings,

I tried to add the [GP2Y0A51SK0F ](http://www.robotshop.com/en/sharp-gp2y0a51sk0f-analog-distance-sensor-2cm-15cm.html)sensor, by adding the following:

```
  // SharpDistSensor.h
  enum models
  {
    // Constant for GP2Y0A60SZLF 5V model
    GP2Y0A60SZLF_5V,
    // Constant for GP2Y0A710K0F 5V model
    GP2Y0A710K0F_5V_DS,
    // Constant for GP2Y0A51SK0F 5V model
    GP2Y0A51SK0F
  };
```

```
 // SharpDistSensor.cpp
 case GP2Y0A51SK0F:
    {
      // Set coefficients and range for Sharp GP2Y0A51SK0F 5V
      float coeffs[] = {2.005E+02, 1.002E+01, -3.892E-01, 5.299E-03, -3.240E-05,
                        7.492E-08};
      setPolyFitCoeffs(6, coeffs, 100, 221);
      break;
    }
```

I got the coefficients by using this [site ](http://polynomialregression.drque.net/online.php)for the polynomial regression, from my own data:
```
/* 
distance[mm]*	AnalogRead
        47	   221
        57	   191
        67	   168
        77	   146
        87	   134
        97	   122
        107	   112
        117	   104
        122	   100
*the sensor is already mounted, thats why I can't measure the full spectrum yet */
```
But unfortunetly is didn't worked well, it only shows the right distance for 117mm, the rest is nonsense. Although the analogRead values  compared with the [datasheet ](http://www.robotshop.com/media/files/pdf/GP2Y0A41SK0F.pdf.pdf)from the GP2Y0A51SK0F sensor are seems to be right. (Voltage output = 5V / 1024 * analogRead)

So maybe you have an idea, what went wrong to get the right distance?